### PR TITLE
Update The Config.yml to add a Commented Line for Dev Builds of Folia…

### DIFF
--- a/worldedit-bukkit/src/main/resources/defaults/config.yml
+++ b/worldedit-bukkit/src/main/resources/defaults/config.yml
@@ -151,3 +151,7 @@ debug: false
 show-help-on-first-use: true
 server-side-cui: true
 command-block-support: false
+#
+# Uncommenting The Line Below: You Agree with the statement that you --WILL NOT GET SUPPORT WITH THIS FLAG--
+# 
+#allow-editing-on-unsupported-versions: "I accept that I will receive no support with this flag enabled."


### PR DESCRIPTION
…... like 1.21.1-DEV when 1.20.6 is only supported at the moment.

allow-editing-on-unsupported-versions: "I accept that I will receive no support with this flag enabled."

This is really hidden, only way I found this was looking into the source code. I recommend for future Folia WorldEdit builds is having this commented, reason is that the user will be agreeing that they will NOT GET SUPPORT when they remove the comment to allow unsupported versions... (or future versions like the devs builds).