### PR TITLE
Fix schematic tab completion for filenames with spaces

### DIFF
--- a/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/SchematicConverter.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/command/argument/SchematicConverter.java
@@ -63,8 +63,17 @@ public class SchematicConverter implements ArgumentConverter<Path> {
         SchematicsManager schematicsManager = worldEdit.getSchematicsManager();
         Path schematicsRootPath = schematicsManager.getRoot();
 
+        String normalizedInput = input.startsWith("\"") ? input.substring(1) : input;
+
         return limitByPrefix(schematicsManager.getSchematicPaths().stream()
-                .map(s -> schematicsRootPath.relativize(s).toString()), input);
+                .map(s -> schematicsRootPath.relativize(s).toString()), normalizedInput)
+            .stream()
+            .map(SchematicConverter::quoteIfNeeded)
+            .toList();
+    }
+
+    private static String quoteIfNeeded(String path) {
+        return path.indexOf(' ') >= 0 ? '"' + path + '"' : path;
     }
 
     @Override

--- a/worldedit-core/src/main/java/com/sk89q/worldedit/internal/command/CommandUtil.java
+++ b/worldedit-core/src/main/java/com/sk89q/worldedit/internal/command/CommandUtil.java
@@ -227,12 +227,19 @@ public class CommandUtil {
             return suggestion;
         }
         String substr = suggestion.getSubstring();
+        if (substr.startsWith("\"")) {
+            return suggestion;
+        }
         // Check if there is a space inside the substring, and suggest starting from there instead.
         int sp = substr.trim().lastIndexOf(' ');
         if (sp < 0) {
             return suggestion;
         }
-        return Substring.wrap(substr.substring(sp + 1), suggestion.getStart() + sp + 1, suggestion.getEnd());
+        int start = suggestion.getStart() + sp + 1;
+        if (start > suggestion.getEnd()) {
+            return suggestion;
+        }
+        return Substring.wrap(substr.substring(sp + 1), start, suggestion.getEnd());
     }
 
     /**

--- a/worldedit-core/src/test/java/com/sk89q/worldedit/command/argument/SchematicConverterTest.java
+++ b/worldedit-core/src/test/java/com/sk89q/worldedit/command/argument/SchematicConverterTest.java
@@ -1,0 +1,115 @@
+/*
+ * WorldEdit, a Minecraft world manipulation toolkit
+ * Copyright (C) sk89q <http://www.sk89q.com>
+ * Copyright (C) WorldEdit team and contributors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.sk89q.worldedit.command.argument;
+
+import com.sk89q.worldedit.WorldEdit;
+import com.sk89q.worldedit.internal.command.CommandUtil;
+import com.sk89q.worldedit.internal.schematic.SchematicsManager;
+import com.sk89q.worldedit.internal.util.Substring;
+import org.enginehub.piston.inject.InjectedValueAccess;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+import java.lang.reflect.Constructor;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class SchematicConverterTest {
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "iron farm-converted.schem",
+        "starter base.schem",
+        "farms/iron farm 2.schem"
+    })
+    void getSuggestionsQuotesAnySchematicNameContainingSpaces(String schematicName) throws Exception {
+        SchematicConverter converter = newConverterWithSchematics(Set.of(schematicName));
+        String normalizedName = Path.of(schematicName).toString();
+
+        assertEquals(List.of(quote(normalizedName)), converter.getSuggestions(typedPrefix(normalizedName), mock(InjectedValueAccess.class)));
+        assertEquals(List.of(quote(normalizedName)), converter.getSuggestions("\"" + typedPrefix(normalizedName), mock(InjectedValueAccess.class)));
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "iron-farm-converted.schem",
+        "farms/iron-farm-2.schem"
+    })
+    void getSuggestionsLeavesSchematicNamesWithoutSpacesUnquoted(String schematicName) throws Exception {
+        SchematicConverter converter = newConverterWithSchematics(Set.of(schematicName));
+        String normalizedName = Path.of(schematicName).toString();
+
+        assertEquals(
+            List.of(normalizedName),
+            converter.getSuggestions(typedPrefix(normalizedName), mock(InjectedValueAccess.class))
+        );
+    }
+
+    @ParameterizedTest
+    @ValueSource(strings = {
+        "iron farm-converted.schem",
+        "starter base.schem",
+        "farms/iron farm 2.schem"
+    })
+    void fixSuggestionsHandlesQuotedSuggestionsContainingSpaces(String schematicName) {
+        String normalizedName = Path.of(schematicName).toString();
+
+        assertEquals(
+            List.of(quote(normalizedName)),
+            CommandUtil.fixSuggestions(
+                "//schem load ",
+                List.of(Substring.wrap(quote(normalizedName), 13, 13))
+            )
+        );
+    }
+
+    private static SchematicConverter newConverterWithSchematics(Set<String> schematicNames) throws Exception {
+        Path schematicsRoot = Path.of("schematics");
+        WorldEdit worldEdit = mock(WorldEdit.class);
+        SchematicsManager schematicsManager = mock(SchematicsManager.class);
+        when(worldEdit.getSchematicsManager()).thenReturn(schematicsManager);
+        when(schematicsManager.getRoot()).thenReturn(schematicsRoot);
+        when(schematicsManager.getSchematicPaths()).thenReturn(schematicNames.stream()
+            .map(schematicsRoot::resolve)
+            .collect(java.util.stream.Collectors.toSet()));
+
+        return newConverter(worldEdit);
+    }
+
+    private static String typedPrefix(String input) {
+        return input.substring(0, Math.min(4, input.length()));
+    }
+
+    private static String quote(String input) {
+        return '"' + input + '"';
+    }
+
+    private static SchematicConverter newConverter(WorldEdit worldEdit) throws Exception {
+        Constructor<SchematicConverter> constructor = SchematicConverter.class.getDeclaredConstructor(WorldEdit.class);
+        constructor.setAccessible(true);
+        return constructor.newInstance(worldEdit);
+    }
+}


### PR DESCRIPTION
- Quote schematic suggestions that contain spaces
- Preserve quoted suggestions during suggestion remapping
- Add regression tests for schematic paths with and without spaces

Tab-completing `//schem load` could throw when a schematic filename contained spaces.

On Folia, that failure can crash the server after the tab-complete request is handled. This change fixes the issue by quoting schematic suggestions that contain spaces and by ensuring already-quoted suggestions are not reprocessed as separate space-delimited arguments during remapping.